### PR TITLE
Correctly process customer without address

### DIFF
--- a/src/module-loyalty-async/Model/Queue/Builder/Service/ContactBuilder.php
+++ b/src/module-loyalty-async/Model/Queue/Builder/Service/ContactBuilder.php
@@ -91,19 +91,22 @@ class ContactBuilder
      * @return JobInterface
      * @throws LocalizedException
      */
-    public function updateContactAddress(Customer|CustomerInterface $customer): JobInterface
+    public function updateContactAddress(Customer|CustomerInterface $customer): ?JobInterface
     {
         $customerUpdate = $this->requestTypePool->getRequestType(ContactUpdate::getTypeCode());
         $address = $this->getCustomerAddress($customer);
 
-        $customerUpdate = $customerUpdate->setData('address', $address);
-        return $this->jobBuilder
-            ->newJob($customer->getId())
-            ->setStoreId((int) $customer->getStoreId())
-            ->addRequest(
-                $customerUpdate->getPayload(),
-                $customerUpdate::getTypeCode()
-            )->create();
+        if ($address !== null) {
+            $customerUpdate = $customerUpdate->setData('address', $address);
+            return $this->jobBuilder
+                ->newJob($customer->getId())
+                ->setStoreId((int) $customer->getStoreId())
+                ->addRequest(
+                    $customerUpdate->getPayload(),
+                    $customerUpdate::getTypeCode()
+                )->create();
+        }
+        return null;
     }
 
     /**
@@ -129,9 +132,9 @@ class ContactBuilder
     {
         $address = null;
         $defaultBillingId = $customer->getDefaultBilling();
-        foreach ($customer->getAddresses() as $address) {
-            if ($address->getId() === $defaultBillingId) {
-                $address = $address->__toArray();
+        foreach ($customer->getAddresses() as $customerAddress) {
+            if ($customerAddress->getId() === $defaultBillingId) {
+                $address = $customerAddress->__toArray();
                 break;
             }
         }


### PR DESCRIPTION
When a customer does not have an address, do no try to update address in Leat.
This merge will fix an incorrect check and added a null return for updateContactAddress function.

The loop did override the return value. It is now using its own variable to prevent this.