### PR TITLE
Added null check for product

### DIFF
--- a/src/module-loyalty/Helper/GiftcardHelper.php
+++ b/src/module-loyalty/Helper/GiftcardHelper.php
@@ -129,7 +129,11 @@ class GiftcardHelper
      */
     public function itemIsGiftcard(AbstractItem|AbstractModel $item): bool
     {
-        return $this->productIsGiftcard($item->getProduct()->getId());
+        $product = $item->getProduct();
+        if ($product === null) {
+            return false;
+        }
+        return $this->productIsGiftcard($product->getId());
     }
 
     /**


### PR DESCRIPTION
Make sure that a product is given before trying to get its Id. Some orders might have an item without a product