### PR TITLE
Cast int to string

### DIFF
--- a/src/module-loyalty-frontend/Block/Widget/ActivityLog.php
+++ b/src/module-loyalty-frontend/Block/Widget/ActivityLog.php
@@ -139,7 +139,7 @@ class ActivityLog extends GenericWidgetBlock
             // Process each group into a single activity item
             $processedTransactions = [];
             foreach ($groupedTransactions as $groupId => $transactionGroup) {
-                $processedTransactions[] = $this->processTransactionGroup($groupId, $transactionGroup);
+                $processedTransactions[] = $this->processTransactionGroup((string)$groupId, $transactionGroup);
             }
 
             // Sort by date, newest first


### PR DESCRIPTION
$groupId might be an int instead of a string required by the processTransactionGroup. Cast it to a string. 